### PR TITLE
ELEC-274: Strip device macros from template

### DIFF
--- a/templates/can_msg_defs.mako.h
+++ b/templates/can_msg_defs.mako.h
@@ -18,11 +18,6 @@ typedef enum {
   ${helpers.generate_enum(can_messages, 'CAN_MESSAGE')}
 } CanMessage;
 
-% for _, dev_name in can_devices.items():
-#define CAN_MSG_ACK_DEVICE_${dev_name} 1 << CAN_DEVICE_${dev_name}
-
-% endfor
-
 <% can_frames = parse_can_frames(options.filename) %> \
 #define CAN_MSG_IS_CRITICAL(msg_ptr) \
   ( \


### PR DESCRIPTION
Quick cleanup PR that just removes the macros I committed too quickly in (#8).