### PR TITLE
ELEC-105: Update Heartbeats for Chaos

### DIFF
--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -15,7 +15,8 @@ msg {
   msg_name: "bps fault"
   is_critical: true
   can_data {
-    empty {
+    u8 {
+      field_name_1: "status"
     }
   }
 }
@@ -85,7 +86,19 @@ msg {
   }
 }
 
-# IDs: 5-15 Reserved
+msg {
+  id: 6
+  source: CHAOS
+  # target: PLUTUS, MOTOR_CONTROLLER, DRIVER_CONTROLS
+  msg_name: "powertrain heartbeat"
+  is_critical: true
+  can_data {
+    empty {
+    }
+  }
+}
+
+# IDs: 7-15 Reserved
 
 msg {
   id: 16

--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -12,7 +12,7 @@ msg {
   id: 0
   source: PLUTUS
   # target: CHAOS, LIGHTS
-  msg_name: "bps fault"
+  msg_name: "bps heartbeat"
   is_critical: true
   can_data {
     u8 {

--- a/templates/can_pack.mako.h
+++ b/templates/can_pack.mako.h
@@ -14,10 +14,10 @@
     % endfor
     % if frame.ftype != 'empty':
       ) \
-      can_pack_impl_${frame.ftype}((msg_ptr), SYSTEM_CAN_DEVICE_${frame.source}, CAN_MESSAGE_${frame.msg_name}, ${frame.dlc}  \
+      can_pack_impl_${frame.ftype}((msg_ptr), SYSTEM_CAN_DEVICE_${frame.source}, SYSTEM_CAN_MESSAGE_${frame.msg_name}, ${frame.dlc}  \
     % else:
       ) \
-      can_pack_impl_${frame.ftype}((msg_ptr), SYSTEM_CAN_DEVICE_${frame.source}, CAN_MESSAGE_${frame.msg_name} \
+      can_pack_impl_${frame.ftype}((msg_ptr), SYSTEM_CAN_DEVICE_${frame.source}, SYSTEM_CAN_MESSAGE_${frame.msg_name} \
     % endif
     % for field in frame.fields:
       , (${field}_${frame.ftype}) \


### PR DESCRIPTION
Adds a new heartbeat message for the powertrain, updates bps_fault message with a state.

- Powertrain heartbeat message: A heartbeat sent by Chaos that must be ACK'd by Plutus, Motor Controller Interface, and Driver Controls. The priority of this shouldn't matter too much but would people prefer if it was ID # 1 rather than 6?
- BPS Fault: As discussed Plutus now transmits a stateful heartbeat to Chaos so it knows that if the message is bad or not received it must enter and cannot exit emergency stop until an all clear is received. Furthermore, this acts as a watchdog for Chaos as if the message times out it might mean Chaos entered an infinite loop.