### PR TITLE
ELEC-338: Update motor velocity CAN messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,18 @@ install:
 script:
   - make lint
   - make test
+  - make gen
+
+after_success:
+  - zip codegen-tooling-out.zip out/*
+
+deploy:
+  provider: releases
+  api_key:
+    secure: L771x98NsBBWYdTHds9PUPL0uhtpbb3Sl3hLVt14Pssz6NbuuEYTaueQSEAhDbcdxaLWkAoZeEyLoZ30qZX/P8TzFdBGAsm6AnEh7nbqLKruMr/3SpNSEmT0V8v0pgXVVaev6Nw5dFFtinjdgaUlP9dwYugcTzKaPPStE02HyJB6r06WSdhSOxiX1+/HcDhjr+kg/pChHOlEjcbFE7QaRY6dvIZNFpa2O2JLjd1AbnZ9DhTfI/xtgbtLehc8lNUfNrxRPjR8qcYWwY6ni8/BVVrlPU/G8U50iXesswsmJtjb/7qoZEmacIKm4OmFSjXUu8QBHU29Ccz+ZypeMC1rEH11yL9pyOoJeHp/VdiO8HCeVr4oP5QedKaT7LT/dIoMhaoCt0gt1xQehJwsl1VdA8n+xAvBRANfA6O1nCa2B/joODEocCWWYtf0TWsW+psCykD52B6MLDJzsXZeaTbnrq2rscNXpx0MDAgf8d5ttw0ODaQ+ZO59sz9ghUMAA8wIyeg2cuLG5o2mdLsq85044NUxXim9tOO3ijje7OrWrk3AagzM/57gG0V+tupG7qoEZ9AnSpon0xsjBKByp2DcxfsWhMFyVG2bxVbSYxcqIgGYIroNNpfYKmgc2dyK2fiPuHa3z1Xr8oijVviFvSbca4wC/F/hd2xAajNehbAUaHU=
+  file:
+    - codegen-tooling-out.zip
+  skip_cleanup: true
+  on:
+    repo: uw-midsun/codegen-tooling
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - make test
   - make gen
 
-after_success:
+before_deploy:
   - zip codegen-tooling-out.zip out/*
 
 deploy:

--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -259,11 +259,11 @@ msg {
   id: 36
   source: MOTOR_CONTROLLER
   # target: DRIVER_DISPLAY, TELEMETRY
-  msg_name: "motor velocity l"
+  msg_name: "motor velocity"
   can_data {
     u32 {
-      field_name_1: "vehicle_velocity"
-      field_name_2: "angular_freq"
+      field_name_1: "vehicle_velocity_left"
+      field_name_2: "vehicle_velocity_right"
     }
   }
 }
@@ -272,11 +272,11 @@ msg {
   id: 37
   source: MOTOR_CONTROLLER
   # target: DRIVER_DISPLAY, TELEMETRY
-  msg_name: "motor velocity r"
+  msg_name: "motor angular frequency"
   can_data {
     u32 {
-      field_name_1: "vehicle_velocity"
-      field_name_2: "angular_freq"
+      field_name_1: "angular_freq_left"
+      field_name_2: "angular_freq_right"
     }
   }
 }


### PR DESCRIPTION
Couple of changes here:

1. Separate the motor velocity and angular frequency messages
2. Automate the releases

The proposed workflow for 2 is as follows:

1. Normal PR workflow
1. When a new release needs to be created, we tag a new release in the GitHub UI, which kicks off a new CI build
1. When the CI build succeeds, it attempts to zip the build artifacts (only if a deploy is going to occur)
1. If a tag is detected (`tags: true`), then it deploys (`codegen-tooling-out.zip`) to that tagged release

I _think_ this should work (assuming I didn't mess up encrypting the deploy token), but if it doesn't we can just go back to the manual way :joy: This way we don't need to manually upload an archive each time :)