### PR TITLE
ELEC-128: Fix safelist filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ python:
 branches:
   only:
     - master
+    # regex expression to match our build tagging format (e.g. v1.0.0)
+    # https://docs.travis-ci.com/user/customizing-the-build/#Safelisting-or-blocklisting-branches
+    - /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)/
 
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
Update branch name regex in the safelist, so that tagged builds actually run (see [Travis Documentation](https://docs.travis-ci.com/user/customizing-the-build#Safelisting-or-blocklisting-branches)).

Here's the currently failing request on [Travis](https://travis-ci.org/uw-midsun/codegen-tooling/requests):

![image](https://user-images.githubusercontent.com/6836385/37734622-208a49c8-2d22-11e8-99de-9cb51bae114b.png)
