### PR TITLE
ELEC-392: Remove "mechanical brake" DRIVER_CONTROLS message

### DIFF
--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -195,8 +195,19 @@ msg {
   }
 }
 
+msg {
+  id: 28
+  source: DRIVER_CONTROLS
+  # target: TELEMETRY
+  msg_name: "steering angle"
+  can_data {
+    u16 {
+      field_name_1: "steering_angle"
+    }
+  }
+}
 
-# IDs: 28-30 Reserved
+# IDs: 29-30 Reserved
 
 msg {
   id: 31


### PR DESCRIPTION
This has now been merged into the "motor controls" message, and the 
steering angle is now removed. If we want the steering angle still,
it can be moved to its own telemetry message.