### PR TITLE
ELEC-355: Update Charger Message Paradigm

### DIFF
--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -176,9 +176,11 @@ msg {
   id: 26
   source: CHARGER
   # target: CHAOS
-  msg_name: "charging req"
+  msg_name: "charger conn state"
+  msg_readable_name: "charger connection state"
   can_data {
-    empty {
+    u8 {
+      field_name_1: "is_connected"
     }
   }
 }
@@ -187,10 +189,10 @@ msg {
   id: 27
   source: CHAOS
   # target: CHARGER
-  msg_name: "charging permission"
+  msg_name: "charger set state"
   can_data {
     u8 {
-      field_name_1: "allowed"
+      field_name_1: "state"
     }
   }
 }

--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -189,7 +189,7 @@ msg {
   id: 27
   source: CHAOS
   # target: CHARGER
-  msg_name: "charger set state"
+  msg_name: "charger set relay state"
   can_data {
     u8 {
       field_name_1: "state"


### PR DESCRIPTION
Simple change to convert charger messages from Request/Permission paradigm to Notify/Command paradigm.