### PR TITLE
ELEC-450: Add Plutus Slave and Current Message

### DIFF
--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -274,19 +274,30 @@ msg {
   id: 32
   source: PLUTUS
   # target: DRIVER_DISPLAY, TELEMETRY
-  msg_name: "battery vct"
-  msg_readable_name: "battery voltage current temperature"
+  msg_name: "battery vt"
+  msg_readable_name: "battery voltage temperature"
   can_data {
     u16 {
       field_name_1: "module_id"
       field_name_2: "voltage"
-      field_name_3: "current"
-      field_name_4: "temperature"
+      field_name_3: "temperature"
     }
   }
 }
 
-# IDs: 33-34 Reserved
+msg {
+  id: 33
+  source: PLUTUS
+  # target: DRIVER_DISPLAY, TELEMETRY
+  msg_name: "battery current"
+  can_data {
+    u32 {
+      field_name_1: "current"
+    }
+  }
+}
+
+# IDs: 34 Reserved
 
 msg {
   id: 35

--- a/schema/can.proto
+++ b/schema/can.proto
@@ -28,11 +28,12 @@ message FrameU32 {
 
 // NEXT TAG = 2
 message FrameU64 {
-  string field_name_1 = 1; //
+  string field_name_1 = 1;  //
 }
 
 // NEXT TAG = 1
-message FrameEmpty {}
+message FrameEmpty {
+}
 
 // NEXT TAG = 7
 message CanData {
@@ -46,27 +47,29 @@ message CanData {
   }
 }
 
-// NEXT TAG = 12
+// NEXT TAG = 9
 message CanMsg {
   enum Source {
-    PLUTUS = 0;
-    CHAOS = 1;
-    TELEMETRY = 2;
-    LIGHTS_FRONT = 3;
-    LIGHTS_REAR = 4;
-    MOTOR_CONTROLLER = 5;
-    DRIVER_CONTROLS = 6;
-    DRIVER_DISPLAY = 7;
-    SOLAR_MASTER_FRONT = 8;
-    SOLAR_MASTER_REAR = 9;
-    SENSOR_BOARD = 10;
-    CHARGER = 11;
+    RESERVED = 0;  // enum must contain 0 in protobuf.
+    PLUTUS = 1;
+    PLUTUS_SLAVE = 2;
+    CHAOS = 3;
+    TELEMETRY = 4;
+    LIGHTS_FRONT = 5;
+    LIGHTS_REAR = 6;
+    MOTOR_CONTROLLER = 7;
+    DRIVER_CONTROLS = 8;
+    DRIVER_DISPLAY = 9;
+    SOLAR_MASTER_FRONT = 10;
+    SOLAR_MASTER_REAR = 11;
+    SENSOR_BOARD = 12;
+    CHARGER = 13;
   }
 
-  uint32 raw_id = 1; // 0-2047 only
-  Source source = 2; // 0-15 only
+  uint32 raw_id = 1;  // 0-2047 only
+  Source source = 2;  // 0-15 only
   bool is_ack = 3;
-  uint32 id = 4; // 0-63 only
+  uint32 id = 4;  // 0-63 only
   CanData can_data = 5;
   string msg_name = 6;
   string msg_readable_name = 7;
@@ -75,5 +78,5 @@ message CanMsg {
 
 // NEXT TAG = 2
 message CanSchema {
-  repeated CanMsg msg = 1; //
+  repeated CanMsg msg = 1;  //
 }


### PR DESCRIPTION
Note this introduces a `RESERVED` device as in order for the default proto3 value of 0 to be valid it must have meaning in the context of the enum.