### PR TITLE
ELEC-524: Add motor controller reset message

### DIFF
--- a/can_messages.asciipb
+++ b/can_messages.asciipb
@@ -124,7 +124,18 @@ msg {
   }
 }
 
-# IDs: 9-15 Reserved
+# IDs: 9-14 Reserved
+msg {
+  id: 15
+  source: DRIVER_CONTROLS
+  # target: MOTOR_INTERFACE
+  msg_name: "motor controller reset"
+  can_data {
+    empty {
+    }
+  }
+}
+
 
 msg {
   id: 16


### PR DESCRIPTION
This message will send a reset command to both motor controllers
(left + right).