### PR TITLE
ELEC-334: Rename CANMessage to CanMessage

### DIFF
--- a/templates/can_transmit.mako.h
+++ b/templates/can_transmit.mako.h
@@ -24,7 +24,7 @@
     % endfor 
     ) \
     ({ \
-    CANMessage msg = { 0 }; \
+    CanMessage msg = { 0 }; \
     CAN_PACK_${frame.msg_name}(&msg \
     % for field in frame.fields: 
       , (${field}_${frame.ftype}) \


### PR DESCRIPTION
I thought that we should probably make use of the time before people start 
branching off `master` and get some code quality changes in.

This is required to tackle ELEC-334, in order to get all the CAN-related 
`typedefs` renamed. A lot of the changes reference `CANMessage`, whose values
are autogenerated by this template.

We should aim to get these code quality changes in ASAP.