### PR TITLE
ELEC-573: Add support for Golang Templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,11 @@ notifications:
 
 dist: trusty
 
-matrix:
-  include:
-    - language: python
-      python:
-        - '2.7'
-        - '3.3'
-        - '3.4'
-    - language: go
+language: python
+python:
+  - '2.7'
+  - '3.3'
+  - '3.4'
 
 branches:
   only:
@@ -18,6 +15,7 @@ branches:
 
 before_install:
   - sudo apt-get -qq update
+  - sudo apt-get install golang
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,16 @@ notifications:
 
 dist: trusty
 
-language: python
-python:
-  - '2.7'
-  - '3.3'
-  - '3.4'
+matrix:
+  - include:
+    language: python
+    python:
+      - '2.7'
+      - '3.3'
+      - '3.4'
+
+  - include:
+    language: go
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,13 @@ notifications:
 dist: trusty
 
 matrix:
-  - include:
-    language: python
-    python:
-      - '2.7'
-      - '3.3'
-      - '3.4'
-
-  - include:
-    language: go
+  include:
+    - language: python
+      python:
+        - '2.7'
+        - '3.3'
+        - '3.4'
+    - language: go
 
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ gen: protos
 	@echo "Generating from templates..."
 	@python codegen/build.py 
 	@find out -type f \( -iname '*.[ch]' -o -iname '*.ts' \) | xargs -r clang-format -i -fallback-style=Google
+	@find out -type f \( -iname '*.go'  \) | xargs -r gofmt -w
 
 lint:
 	@echo "Linting..."

--- a/helpers/helpers.mako
+++ b/helpers/helpers.mako
@@ -19,3 +19,24 @@ Args:
   % endfor
   NUM_${prefix}S = ${len(data)} \
 </%def>
+
+<%doc>
+Helps generating enum body content in the format:
+
+    prefix_val0 type = 0,
+    prefix_val1 type = 2,
+    prefix_val2 type = 5,
+    ...
+
+Args:
+    data: a dictionary of data in the range (empty values should have a value of None)
+    prefix: the prefix to use
+    go_type: the type in go
+</%doc>
+<%def name="generate_enum_go(data, prefix, go_type)"> \
+  % for key, value in data.items():
+    % if value != None:
+    ${prefix}${''.join(x.title() for x in value.split('_'))} ${go_type} = ${key}
+    % endif
+  % endfor
+</%def>

--- a/templates/can_msg_defs.mako.go
+++ b/templates/can_msg_defs.mako.go
@@ -1,0 +1,18 @@
+<%namespace name="helpers" file="/helpers/helpers.mako" /> \
+<% from data import NUM_CAN_MESSAGES, NUM_CAN_DEVICES, parse_can_device_enum, parse_can_message_enum, parse_can_frames %> \
+package CanMsgDefs
+
+type CanDeviceId uint16
+type CanMsgId uint32
+
+// For setting the CAN device
+const (
+  <% can_devices = parse_can_device_enum() %> \
+${helpers.generate_enum_go(can_devices, 'SystemCanDevice', 'CanDeviceId')}
+)  
+
+// For setting the CAN message ID
+const (
+  <% can_messages = parse_can_message_enum(options.filename) %> \
+${helpers.generate_enum_go(can_messages, 'SystemCanMessage', 'CanMsgId')}
+)


### PR DESCRIPTION
This PR configures Travis to support Golang and build Golang templates.

The reason for this is to support faking of data in Go to aid in website development.

As we switch to DBC; the future of Code-gen in MSXIV is as follows as far as I understand it;

- Go can use the generated C code for decoding CAN messages over SocketCAN this can be used to serve the telemetry dashboards as we have currently been doing.
- We will need to continue to support some kind of Codegen for the website dashboards be it JS or TS in order to decode JSON which will be sent over the websocket.
- The firmware repo will eventually deprecate codegen in favor of DBC decoders.
- Protobufs should be replaced with DBC and any codegen should be based on the DBC files rather than protobufs.