### PR TITLE
ELEC-268: Add DBC shim script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ pip-selfcheck.json
 # Build artifacts
 out/
 genfiles/
+
+system_can.dbc

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
   - make lint
   - make test
   - make gen
+  - make gen-dbc
 
 before_deploy:
   - zip codegen-tooling-out.zip out/*
@@ -39,7 +40,9 @@ deploy:
   provider: releases
   api_key:
     secure: CT4XLLqlq8ZjObfWiP3xcz1aaG+3xbb3NGhL3IN0LVUUk9ADrbI3qE66OX5gEgI5AIpa1uEruD5+vCG27m6xTszrh/EXRhj/6Y/MtkReBmQL1jndR8sWHLN7rEN9dtG0t3LYivXAbmcF3jIQ/sWkUF64z8yAWeXJITBqyLhU77gE2iQ9WU2Yzlwyq9X+EBGR36jKvsmNw5vabqBTeGbqtnJpIdeXM2HF2iwK5ATHcLudzs0OIAqd2NjGfAt5Y8qEUWUWobcc+qxw+Mz/xue+054kSzd03MqSgmDRvxXNieaG5U6e//pzwUpuFlSLud6tBzStjO8K34jusyn9ONTKWcvfYbmPV4NqX60puYZrucUIeGsvn2RtBQY2WqzH3UmYKQVkcO8QlfXAPB1ewiB0mbRxx3ijypNc4hqWQiLunyCDrSuAFBV9h1mMeIKEgPmmgYS24U+1HfSbLWuh0i18eosNvtxwgDiYI6f+Uov0zUda59PCWB0QKZqFajKMypa+3EgHjqtO0kRburBEl7Fm2TMWadwAxae2mFJ9rW9vV6BHus5YPF3oZjrbbn570PZK5LzSDWh++qokj62/PSrIXhRsSU4Z64pex4+vC3GzmVQAzjhWyW8MKXEbGj8K6SEMHYiAgVbmFp2kFphHgMqjtz/lOSFZPNVqzyzDnBmBfDg=
-  file: codegen-tooling-out.zip
+  file:
+    - codegen-tooling-out.zip
+    - system_can.dbc
   skip_cleanup: true
   on:
     repo: uw-midsun/codegen-tooling

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ gen: protos
 	@find out -type f \( -iname '*.[ch]' -o -iname '*.ts' \) | xargs -r clang-format -i -fallback-style=Google
 	@find out -type f \( -iname '*.go'  \) | xargs -r gofmt -w
 
+gen-dbc:
+	@echo "Generating DBC file"
+	@python codegen/build_dbc.py
+
 lint:
 	@echo "Linting..."
 	@pylint --disable=F0401 codegen/

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,31 @@
-.PHONY: lint protos gen test clean
-
+.PHONY: gen
 gen: protos
 	@echo "Generating from templates..."
 	@python codegen/build.py 
 	@find out -type f \( -iname '*.[ch]' -o -iname '*.ts' \) | xargs -r clang-format -i -fallback-style=Google
 	@find out -type f \( -iname '*.go'  \) | xargs -r gofmt -w
 
+.PHONY: gen-dbc
 gen-dbc:
 	@echo "Generating DBC file"
 	@python codegen/build_dbc.py
 
+.PHONY: lint
 lint:
 	@echo "Linting..."
 	@pylint --disable=F0401 codegen/
 
+.PHONY: protos 
 protos:
 	@echo "Compiling protos..."
 	@mkdir -p genfiles
 	@protoc -I=schema --python_out=genfiles --go_out=genfiles schema/can.proto
 
+.PHONY: test
 test: gen
 	@echo "Testing..."
 	@python -m unittest discover -s codegen
 
+.PHONY: clean
 clean:
 	@rm -rf genfiles out

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -76,28 +76,17 @@ def main():
             #
             # due to CANdlelight 1.0 alignment rules.
             results = []
-            # Generate the signal used as the multiplexer
-            # TODO: This is kind of a hack, but idk
+
+            # Generate the signal used as the multiplexer. This is the `id`
+            # field comprising of the first 2 bytes (even though only 7 bits
+            # are necessary), since Voltage and Temperature are both 16-bit
+            # values.
             multiplexer = cantools.database.can.Signal(
                  name='BATTERY_VT_INDEX',
                  start=0,
                  length=16,
-                 byte_order='little_endian',
-                 is_signed=False,
-                 scale=1,
-                 offset=0,
-                 minimum=None,
-                 maximum=None,
-                 unit=None,
-                 choices=None,
-                 dbc_specifics=None,
-                 comment=None,
-                 receivers=None,
-                 is_multiplexer=True,
-                 multiplexer_ids=None,
-                 multiplexer_signal=None,
-                 is_float=False,
-                 decimal=None)
+                 is_multiplexer=True
+            )
             results.append(multiplexer)
 
             # Generate all the multiplexed signals for the Module Voltage and
@@ -108,18 +97,6 @@ def main():
                     name='MODULE_VOLTAGE_{0:03d}'.format(i),
                     start=16,
                     length=16,
-                    byte_order='little_endian',
-                    is_signed=False,
-                    scale=1,
-                    offset=0,
-                    minimum=None,
-                    maximum=None,
-                    unit=None,
-                    choices=None,
-                    dbc_specifics=None,
-                    comment=None,
-                    receivers=None,
-                    is_multiplexer=False,
                     # The multiplexed ID is just the Cell Index
                     multiplexer_ids=[i],
                     # The multiplexer is the Module index
@@ -134,17 +111,6 @@ def main():
                     start=32,
                     length=16,
                     byte_order='little_endian',
-                    is_signed=False,
-                    scale=1,
-                    offset=0,
-                    minimum=None,
-                    maximum=None,
-                    unit=None,
-                    choices=None,
-                    dbc_specifics=None,
-                    comment=None,
-                    receivers=None,
-                    is_multiplexer=False,
                     # The multiplexed ID is just the Cell Index
                     multiplexer_ids=[i],
                     # The multiplexer is the Module index
@@ -158,9 +124,6 @@ def main():
 
             return results
 
-        # TODO: iirc, only ACKs have DLC 0, otherwise everything else has a
-        # DLC of 8. Check this tho
-        #
         # All these message types must be Data messages. ACK messages are
         # currently handled implicitly by the protocol layer, and will be
         # generated based on whether or not it is an ACKable message.
@@ -305,20 +268,17 @@ def main():
                 msg_id=msg_id
             )
 
-            # TODO: ack_status
+            # All ACK responders send a message containing a ACK_STATUS in
+            # CANdlelight 1.0
             signals = [
                 cantools.database.can.Signal(
                     name='{}_FROM_{}_ACK_STATUS'.format(msg_name, sender),
                     start=0,
-                    length=8,
-                    byte_order='little_endian',
-                    is_signed=False,
-                    scale=1,
-                    offset=0,
-                    is_float=False
+                    length=8
                 )
             ]
-            # TODO: properly calculate length calculation
+            # This ACK message is always length 1, since it just fits the
+            # ACK_STATUS
             message = cantools.database.can.Message(
                 frame_id=frame_id,
                 name='{}_ACK_FROM_{}'.format(msg_name, sender),

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -61,8 +61,12 @@ def main():
         source = get_key_by_val(device_enum, can_frame.source)
         # TODO: iirc, only ACKs have DLC 0, otherwise everything else has a
         # DLC of 8. Check this tho
+        #
+        # All these message types must be Data messages. ACK messages are
+        # currently handled implicitly by the protocol layer, and will be
+        # generated based on whether or not it is an ACKable message.
         frame_id = build_arbitration_id(
-            msg_type=can_frame.is_critical,
+            msg_type=0,
             source_id=source,
             msg_id=msg_id
         )
@@ -147,16 +151,17 @@ def main():
                 print("Couldn't find {}".format(sender))
 
             frame_id = build_arbitration_id(
-                msg_type=0,
+                msg_type=1,
                 source_id=sender_id,
                 msg_id=msg_id
             )
 
             signals = []
+            # TODO: properly calculate length calculation
             message = cantools.database.can.Message(
                 frame_id=frame_id,
-                name='{}_ACK'.format(msg_name),
-                length=8,
+                name='{}_ACK_FROM_{}'.format(msg_name, sender),
+                length=1,
                 signals=signals,
                 # The sender is the Message Source
                 senders=[sender]

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -182,22 +182,15 @@ def main():
                         name=field,
                         start=index*length,
                         length=length,
-                        byte_order='little_endian',
-                        is_signed=True,
-                        scale=1,
-                        offset=0,
-                        is_float=False
+                        is_signed=True
                     )
                 else:
+                    # battery voltage is unsigned
                     signal = cantools.database.can.Signal(
                         name=field,
                         start=index*length,
                         length=length,
-                        byte_order='little_endian',
-                        is_signed=False,
-                        scale=1,
-                        offset=0,
-                        is_float=False
+                        is_signed=False
                     )
                 signals.append(signal)
                 total_length += length

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -1,0 +1,178 @@
+"""
+This script generates a DBC file from our custom protobufs in order to make the
+transition to DBCs more seamless. This is a temporary measure so we can
+continue to use codegen-tooling, while switching over to using DBC decoders so
+we do not have to maintain the dump scripts.
+
+The idea is that we will eventually switch over to DBC files, or a higher level
+DSL that compiles down into DBC files (ie. if our CAN protocol changes).
+"""
+import cantools
+
+# For the proto and asciipb parsing
+import data
+
+def build_arbitration_id(msg_type, source_id, msg_id):
+    """
+    typedef union CanId {
+      uint16_t raw;
+      struct {
+        uint16_t source_id : 4;
+        uint16_t type : 1;
+        uint16_t msg_id : 6;
+      };
+    } CanId;
+    """
+    return ((source_id & ((0x1 << 4) - 1)) << (0)) | \
+            ((msg_type & ((0x1 << 1) - 1)) << (4)) | \
+            ((msg_id & ((0x1 << 6) - 1)) << (4 + 1))
+
+def main():
+    db = cantools.database.can.Database(version='')
+
+    # Iterate through all the CAN device IDs and add them to the DBC.
+    can_devices = data.parse_can_device_enum()
+    for device_id, device_name in can_devices.items():
+        if device_name not in [ 'RESERVED' ]:
+            node = cantools.database.can.Node(
+                name=device_name,
+                comment='Device ID: {}'.format(hex(device_id))
+            )
+            db.nodes.append(node)
+
+    # Iterate through all the CAN messages IDs and:
+    #
+    #   1. Convert the Message ID to the CAN Arbitration ID.
+    #   2. Add the Message to the DBC.
+    #   3. For each of the signals, add it to the Message.
+    #   4. If the Message is critical, add an ACK message to the DBC.
+    can_messages = data.parse_can_frames('can_messages.asciipb')
+    device_enum = data.parse_can_device_enum()
+
+
+    FIELDS_LEN = { 'u8': 8, 'u16': 16, 'u32': 32, 'u64': 64 }
+    def get_key_by_val(d, val):
+        for k, v in d.items():
+            if val == v:
+                return k
+        return None
+
+    for msg_id, can_frame in can_messages.items():
+        source = get_key_by_val(device_enum, can_frame.source)
+        # TODO: iirc, only ACKs have DLC 0, otherwise everything else has a
+        # DLC of 8. Check this tho
+        frame_id = build_arbitration_id(
+            msg_type=can_frame.is_critical,
+            source_id=source,
+            msg_id=msg_id
+        )
+
+        signals = []
+        for index, field in enumerate(can_frame.fields):
+            length = FIELDS_LEN[can_frame.ftype]
+
+            # Unfortunately, our asciipb doesn't denote whether a field is
+            # signed/unsigned, and it is up to the caller to properly unpack
+            # the CAN signal.
+            #
+            # In this case, it's probably easier to just assume everything is
+            # unsigned and then force people to make a manual pass through and
+            # mark things as appropriate.
+            #
+            # TBH, we only have a few signals that are signed.
+            signal = cantools.database.can.Signal(
+                name=field,
+                start=index*length,
+                length=length,
+                byte_order='little_endian',
+                is_signed=False,
+                scale=1,
+                offset=0,
+                is_float=False
+            )
+            signals.append(signal)
+
+        message = cantools.database.can.Message(
+            frame_id=frame_id,
+            name=can_frame.msg_name,
+            length=8,
+            signals=signals,
+            # The sender is the Message Source
+            senders=[can_frame.source]
+        )
+        db.messages.append(message)
+
+        # If this requires an ACK, then we go through all of the receivers.
+        # Unfortunately, our asciipb file doesn't have a notion of Receivers,
+        # so we hardcode this.
+        ACKABLE_MESSAGES = {
+            0: [
+                'CHAOS',
+                'LIGHTS_FRONT'
+            ],
+            1: [
+                'DRIVER_CONTROLS'
+            ],
+            2: [
+                'PLUTUS'
+            ],
+            3: [
+                'PLUTUS_SLAVE'
+            ],
+            4: [
+                'MOTOR_CONTROLLER'
+            ],
+            5: [
+                'SOLAR_MASTER_REAR'
+            ],
+            6: [
+                'SOLAR_MASTER_FRONT'
+            ],
+            7: [
+                'CHAOS'
+            ],
+            8: [
+                'PLUTUS',
+                'MOTOR_CONTROLLER',
+                'DRIVER_CONTROLS'
+            ],
+        }
+
+        def get_ack(sender, msg_name, msg_id):
+            """
+            msg_id: the id of the message we are ACKing
+            """
+            sender_id = get_key_by_val(device_enum, sender)
+            if sender_id is None:
+                print("Couldn't find {}".format(sender))
+
+            frame_id = build_arbitration_id(
+                msg_type=0,
+                source_id=sender_id,
+                msg_id=msg_id
+            )
+
+            signals = []
+            message = cantools.database.can.Message(
+                frame_id=frame_id,
+                name='{}_ACK'.format(msg_name),
+                length=8,
+                signals=signals,
+                # The sender is the Message Source
+                senders=[sender]
+            )
+            return message
+
+        if msg_id in ACKABLE_MESSAGES:
+            for acker in ACKABLE_MESSAGES[msg_id]:
+                message = get_ack(acker, can_frame.msg_name, msg_id)
+
+                db.messages.append(message)
+
+    # Save as a DBC file
+    with open('test.dbc', 'w') as f:
+        f.write(db.as_dbc_string())
+    return
+
+if __name__ == '__main__':
+    main()

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -25,6 +25,7 @@ FIELDS_LEN = {
     'u64': 64
 }
 
+# pylint: disable=W0511
 # TODO: Determine a way of encoding this in the ASCIIPB
 SIGNED_MESSAGES = [
     'DRIVE_OUTPUT',
@@ -33,6 +34,7 @@ SIGNED_MESSAGES = [
     'MOTOR_VELOCITY'
 ]
 
+# pylint: disable=W0511
 # TODO: Determine a way of encoding this in the ASCIIPB
 ACKABLE_MESSAGES = {
     0: [

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -7,6 +7,8 @@ we do not have to maintain the dump scripts.
 The idea is that we will eventually switch over to DBC files, or a higher level
 DSL that compiles down into DBC files (ie. if our CAN protocol changes).
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import cantools
 
 # For the proto and asciipb parsing

--- a/codegen/build_dbc.py
+++ b/codegen/build_dbc.py
@@ -195,10 +195,10 @@ def main():
                 signals.append(signal)
                 total_length += length
 
-            # TODO: fix length
-            # It is safe to divide by 8 since every single message under the old
-            # protocol (aka. what I call CANdlelight 1.0) is byte-aligned. To be
-            # precise, it uses byte-alignment padding to fit 8, 4, 2, 1 bytes.
+            # Note: It is safe to divide by 8 since every single message under
+            # the old protocol (aka. what I call CANdlelight 1.0) is
+            # byte-aligned. To be precise, it uses byte-alignment padding to
+            # fit 8, 4, 2, 1 bytes.
             message = cantools.database.can.Message(
                 frame_id=frame_id,
                 name=can_frame.msg_name,
@@ -211,7 +211,9 @@ def main():
 
             # If this requires an ACK, then we go through all of the receivers.
             # Unfortunately, our ASCIIPB file doesn't have a notion of Receivers,
-            # so we hardcode this.
+            # so we hardcode this for now.
+            #
+            # TODO: Determine a way of encoding this in the ASCIIPB
             ACKABLE_MESSAGES = {
                 0: [
                     'CHAOS',
@@ -289,7 +291,7 @@ def main():
                 db.messages.append(message)
 
     # Save as a DBC file
-    with open('test.dbc', 'w') as f:
+    with open('system_can.dbc', 'w') as f:
         f.write(db.as_dbc_string())
     return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ isort==4.2.15
 pylint==1.7.2
 nose==1.3.7
 parameterized==0.6.1
+cantools==32.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ isort==4.2.15
 pylint==1.7.2
 nose==1.3.7
 parameterized==0.6.1
-cantools==32.5.2
+cantools==32.11.2


### PR DESCRIPTION
Since nobody's really complained/reported any issues with my DBC file, I'm just going to put up a first pass of the shim script. I'm not really working on it anymore, so it'd be good to get it in.

Migration plan is:

1. Generate a DBC as a build artefact in addition to templates
1. Deprecate python scripts for decoding CAN.
1. Use the DBC to generate C files
1. Replace codegen-tooling library in firmware with the C files generated from the DBC. DBC is now the source of truth
1. Golang can use cgo bindings with C files (or a native-Go library). Same for JS/TS (worst case compile via Emscripten)

There's some `TODOs` that might be worth addressing depending on how long this shim script is around for, but I don't think they'd be major blockers.