### PR TITLE
ELEC-627: Update codegen-tooling setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Assorted code generation utilities and tooling
 
 ## Getting Started
 
+Assuming you have our [Vagrant box](https://github.com/uw-midsun/box) installed:
+
+Start by cloning the codegen-tooling repository in our vagrant box.
+```bash
+git clone git@github.com:uw-midsun/codegen-tooling.git
+cd codegen-tooling
+```
+
 The `protoc` compiler is needed to build protocol buffers on Ubuntu the official
 version is out of date so use the following [ppa](https://launchpad.net/~maarten-fonville/+archive/ubuntu/protobuf) 
 to add it.
@@ -16,41 +24,31 @@ sudo apt-get update
 
 If you already have protoc installed continue from here:
 ```bash
-virtualenv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-make gen
-```
-
-Or if you use ``pyenv``
-
-```bash
-pyenv virtualenv 3.3.6 codegen-tooling336
-source ~/.pyenv/versions/codegen-tooling336/bin/activate
 pip install -r requirements.txt
 make gen
 ```
 
 If you need to generate a new protobuf file
-
 ```bash
 make protos
 ```
 
 If you need to run unittests
-
 ```bash
 make test
 ```
 
 If you need to lint code
-
 ```bash
 make lint
 ```
 
-To clean the outputs
+If you need to generate a DBC
+```bash
+make gen-dbc
+```
 
+To clean the outputs
 ```bash
 make clean
 ```
@@ -60,7 +58,6 @@ To add a new dependency, ``pip install $dependency && pip freeze | grep -i $depe
 ## Requirements
 * Python 2.7+ (or Python 3.3+)
 * [pip](https://pip.pypa.io/en/stable/installing/)
-* [virtualenv](https://virtualenv.pypa.io/en/stable/installation/)
 * protoc 3.0+ (if you're compiling protobufs)
 * clang-format
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Mako==1.0.6
-protobuf==3.2.0
+protobuf==3.7.0
 mock==2.0.0
 astroid==1.5.3
 isort==4.2.15


### PR DESCRIPTION
In preparation for new member on-boarding:
- Clarify setup instructions for codegen-tooling 
- We are transitioning to DBC so we want them to be able to create a new CAN message and generate the DBC accordingly 
- Upgrade to protobuf 3.7, some errors occur when compiling protos with current requirements
